### PR TITLE
Address issues where the Java level would default

### DIFF
--- a/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughPlatformServiceProvider.java
+++ b/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughPlatformServiceProvider.java
@@ -1,12 +1,9 @@
 package org.terracotta.passthrough;
 
-import org.terracotta.entity.ClientCommunicator;
 import org.terracotta.entity.ServiceConfiguration;
-import org.terracotta.entity.ServiceProvider;
 import org.terracotta.monitoring.PlatformService;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@ limitations under the License.
     <java.version>1.6</java.version>
     <terracotta-os-snapshots-url>http://nexus.terracotta.eur.ad.sag/content/repositories/terracotta-os-snapshots</terracotta-os-snapshots-url>
     <terracotta-os-releases-url>http://nexus.terracotta.eur.ad.sag/content/repositories/terracotta-os-releases</terracotta-os-releases-url>
+    <java.build.version>1.6</java.build.version>
 
     <!-- External dependency versions for the project -->
     <terracotta-apis.version>1.0.2.beta</terracotta-apis.version>
@@ -58,6 +59,15 @@ limitations under the License.
             <!-- The server "id" element from settings to use authentication from -->
             <serverId>terracotta-nexus-staging</serverId>
             <skipNexusStagingDeployMojo>${skip.deploy}</skipNexusStagingDeployMojo>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.3</version>
+          <configuration>
+            <source>${java.build.version}</source>
+            <target>${java.build.version}</target>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
This addresses an issue where the target Java version wasn't fixed and could drift based on environmental defaults.

This fixes us on Java6.