### PR TITLE
Fix #6: Pass through the client-provided connection name to management tree

### DIFF
--- a/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughConnection.java
+++ b/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughConnection.java
@@ -48,6 +48,10 @@ import org.terracotta.passthrough.PassthroughMessage.Type;
  * Internally, this runs a single thread to handle incoming ACKs, completions, and messages.
  */
 public class PassthroughConnection implements Connection {
+  // Information that we collect and only pass through for M&M reasons.
+  private final String connectionName;
+  private final String uuid;
+
   private final PassthroughConnectionState connectionState;
   
   private final List<EntityClientService<?, ?, ? extends EntityMessage, ? extends EntityResponse>> entityClientServices;
@@ -72,7 +76,10 @@ public class PassthroughConnection implements Connection {
   private Map<Long, PassthroughWait> waitersToResend;
 
 
-  public PassthroughConnection(String readerThreadName, PassthroughServerProcess serverProcess, List<EntityClientService<?, ?, ? extends EntityMessage, ? extends EntityResponse>> entityClientServices, Runnable onClose, long uniqueConnectionID) {
+  public PassthroughConnection(String connectionName, String readerThreadName, PassthroughServerProcess serverProcess, List<EntityClientService<?, ?, ? extends EntityMessage, ? extends EntityResponse>> entityClientServices, Runnable onClose, long uniqueConnectionID) {
+    this.connectionName = connectionName;
+    this.uuid = java.util.UUID.randomUUID().toString();
+    
     this.connectionState = new PassthroughConnectionState(serverProcess);
     this.entityClientServices = entityClientServices;
     this.nextClientEndpointID = 1;
@@ -95,6 +102,20 @@ public class PassthroughConnection implements Connection {
     
     // Note:  This should probably not be in the constructor.
     this.clientThread.start();
+  }
+
+  /**
+   * @return The name, optionally set by the user via ConnectionPropertyNames.CONNECTION_NAME, in Properties.
+   */
+  public String getConnectionName() {
+    return this.connectionName;
+  }
+
+  /**
+   * @return The UUID assigned to the connection when it was first created.
+   */
+  public String getUUID() {
+    return this.uuid;
   }
 
   /**

--- a/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughConnectionService.java
+++ b/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughConnectionService.java
@@ -24,6 +24,7 @@ import java.util.Properties;
 
 import org.terracotta.connection.Connection;
 import org.terracotta.connection.ConnectionException;
+import org.terracotta.connection.ConnectionPropertyNames;
 import org.terracotta.connection.ConnectionService;
 
 
@@ -54,7 +55,11 @@ public class PassthroughConnectionService implements ConnectionService {
     String serverName = uri.getHost();
     PassthroughServer server = PassthroughServerRegistry.getSharedInstance().getServerForName(serverName);
     if (null != server) {
-      connection = server.connectNewClient();
+      String connectionName = properties.getProperty(ConnectionPropertyNames.CONNECTION_NAME);
+      if (null == connectionName) {
+        connectionName = "";
+      }
+      connection = server.connectNewClient(connectionName);
     } else {
       throw new ConnectionException(new UnknownHostException(serverName));
     }

--- a/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughServer.java
+++ b/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughServer.java
@@ -90,7 +90,7 @@ public class PassthroughServer implements PassthroughDumper {
     this.entityClientServices.add(service);
   }
 
-  public synchronized PassthroughConnection connectNewClient() {
+  public synchronized PassthroughConnection connectNewClient(String connectionName) {
     Assert.assertTrue(this.hasStarted);
     final long thisConnectionID = this.nextConnectionID;
     this.nextConnectionID += 1;
@@ -108,7 +108,7 @@ public class PassthroughServer implements PassthroughDumper {
       }
     };
     String readerThreadName = "Client connection " + thisConnectionID;
-    PassthroughConnection connection = new PassthroughConnection(readerThreadName, this.serverProcess, this.entityClientServices, onClose, thisConnectionID);
+    PassthroughConnection connection = new PassthroughConnection(connectionName, readerThreadName, this.serverProcess, this.entityClientServices, onClose, thisConnectionID);
     this.serverProcess.connectConnection(connection, thisConnectionID);
     this.savedClientConnections.put(thisConnectionID, connection);
     return connection;
@@ -125,7 +125,7 @@ public class PassthroughServer implements PassthroughDumper {
       }
     };
     String readerThreadName = "Pseudo-connection " + thisConnectionID;
-    return new PassthroughConnection(readerThreadName, this.serverProcess, this.entityClientServices, onClose, thisConnectionID);
+    return new PassthroughConnection("internal pseudo-connection", readerThreadName, this.serverProcess, this.entityClientServices, onClose, thisConnectionID);
   }
 
   public void start(boolean isActive, boolean shouldLoadStorage) {

--- a/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
+++ b/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
@@ -974,7 +974,11 @@ public class PassthroughServerProcess implements MessageHandler, PassthroughDump
         // We don't have handling for this.
         Assert.unexpected(e);
       }
-      PlatformConnectedClient clientDescription = new PlatformConnectedClient(java.util.UUID.randomUUID().toString(), "", localHost, this.bindPort, localHost, CLIENT_PORT.getAndIncrement(), Long.parseLong(ManagementFactory.getRuntimeMXBean().getName().split("@")[0]));
+      String uuid = connection.getUUID();
+      Assert.assertTrue(null != uuid);
+      String connectionName = connection.getConnectionName();
+      Assert.assertTrue(null != connectionName);
+      PlatformConnectedClient clientDescription = new PlatformConnectedClient(uuid, connectionName, localHost, this.bindPort, localHost, CLIENT_PORT.getAndIncrement(), Long.parseLong(ManagementFactory.getRuntimeMXBean().getName().split("@")[0]));
       String nodeName = clientIdentifierForService(connectionID);
       this.serviceInterface.addNode(PlatformMonitoringConstants.CLIENTS_PATH, nodeName, clientDescription);
     }


### PR DESCRIPTION
-this was internally hard-coded to an empty string but now is being pulled from the Properties object