### PR TITLE
Fix #20: Expose new methods through IClientTestEnvironment

### DIFF
--- a/passthrough-server/src/main/java/org/terracotta/passthrough/SimpleClientTestEnvironment.java
+++ b/passthrough-server/src/main/java/org/terracotta/passthrough/SimpleClientTestEnvironment.java
@@ -28,16 +28,16 @@ public class SimpleClientTestEnvironment implements IClientTestEnvironment {
   private final int totalClientCount;
   private final int thisClientIndex;
   private final IClusterInfo clusterInfo;
+  private final int numberOfStripes;
+  private final int numberOfServersPerStripe;
 
-  public SimpleClientTestEnvironment(String clusterUri, int totalClientCount, int thisClientIndex) {
-    this(clusterUri, totalClientCount, thisClientIndex, null);
-  }
-
-  public SimpleClientTestEnvironment(String clusterUri, int totalClientCount, int thisClientIndex, IClusterInfo clusterInfo) {
+  public SimpleClientTestEnvironment(String clusterUri, int totalClientCount, int thisClientIndex, IClusterInfo clusterInfo, int numberOfStripes, int numberOfServersPerStripe) {
     this.clusterUri = clusterUri;
     this.totalClientCount = totalClientCount;
     this.thisClientIndex = thisClientIndex;
     this.clusterInfo = clusterInfo;
+    this.numberOfStripes = numberOfStripes;
+    this.numberOfServersPerStripe = numberOfServersPerStripe;
   }
 
   @Override
@@ -58,5 +58,15 @@ public class SimpleClientTestEnvironment implements IClientTestEnvironment {
   @Override
   public IClusterInfo getClusterInfo() {
     return this.clusterInfo;
+  }
+
+  @Override
+  public int getNumberOfStripes() {
+    return this.numberOfStripes;
+  }
+
+  @Override
+  public int getNumberOfServersPerStripe() {
+    return this.numberOfServersPerStripe;
   }
 }

--- a/test-interfaces/src/main/java/org/terracotta/passthrough/IClientTestEnvironment.java
+++ b/test-interfaces/src/main/java/org/terracotta/passthrough/IClientTestEnvironment.java
@@ -42,4 +42,14 @@ public interface IClientTestEnvironment {
    * @return {@link IClusterInfo} which provides information about connecting cluster
    */
   public IClusterInfo getClusterInfo();
+
+  /**
+   * @return The number of stripes in the current environment (always > 0).
+   */
+  public int getNumberOfStripes();
+
+  /**
+   * @return The number of servers within a given stripe in the current environment (always > 0).
+   */
+  public int getNumberOfServersPerStripe();
 }


### PR DESCRIPTION
-getNumberOfStripes() and getNumberOfServersPerStripe()
-note that most users of this class don't support creating multi-stripe test environments