### PR TITLE
Fix #23: Wrap deferred messages in a PassthroughMessage

### DIFF
--- a/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughMessengerService.java
+++ b/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughMessengerService.java
@@ -66,6 +66,10 @@ public class PassthroughMessengerService implements IEntityMessenger {
     @SuppressWarnings("unchecked")
     MessageCodec<EntityMessage, ?> codec = (MessageCodec<EntityMessage, ?>) this.entityContainer.codec;
     byte[] serializedMessage = codec.encodeMessage(newMessageToSchedule);
-    this.passthroughServerProcess.sendMessageToActiveFromInsideActive(newMessageToSchedule, serializedMessage);
+    // We use the invalid instance 0 since this is not a connected client.
+    long clientInstanceID = 0;
+    boolean shouldReplicateToPassives = true;
+    PassthroughMessage passthroughMessage = PassthroughMessageCodec.createInvokeMessage(this.entityClassName, this.entityName, clientInstanceID, serializedMessage, shouldReplicateToPassives);
+    this.passthroughServerProcess.sendMessageToActiveFromInsideActive(newMessageToSchedule, passthroughMessage);
   }
 }

--- a/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
+++ b/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
@@ -361,13 +361,13 @@ public class PassthroughServerProcess implements MessageHandler, PassthroughDump
     }
   }
 
-  public synchronized void sendMessageToActiveFromInsideActive(final EntityMessage newMessage, byte[] serializedMessage) {
+  public synchronized void sendMessageToActiveFromInsideActive(final EntityMessage newMessage, PassthroughMessage passthroughMessage) {
     // Can only happen while running.
     Assert.assertTrue(this.isRunning);
     // This can only be called on the active server.
     Assert.assertTrue(null != this.activeEntities);
     // We must be given a message.
-    Assert.assertTrue(null != serializedMessage);
+    Assert.assertTrue(null != passthroughMessage);
     // This entry-point is only used in the cases where the message already exists.
     Assert.assertTrue(null != newMessage);
     // When handling re-sends, we are effectively paused so this shouldn't happen.
@@ -400,7 +400,7 @@ public class PassthroughServerProcess implements MessageHandler, PassthroughDump
         return -1;
       }
     };
-    container.message = serializedMessage;
+    container.message = passthroughMessage.asSerializedBytes();
     this.messageQueue.add(container);
     this.notifyAll();
   }


### PR DESCRIPTION
-this seems to have just been an oversight in the initial implementation (especially since the non-deferred path does this correctly)
-all messages within passthrough need to be wrapped in a PassthroughMessage so that the server's internal codec can interpret messages that have come into its decoder thread.  This path was sending the serialized version of the actual method, directly