### PR TITLE
Fix #27: Call close() on shutdown for Closeable ServiceProviders

### DIFF
--- a/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughServer.java
+++ b/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughServer.java
@@ -181,6 +181,7 @@ public class PassthroughServer implements PassthroughDumper {
   }
 
   private void internalStop() {
+    this.serverProcess.stop();
     this.serverProcess.shutdown();
     Assert.assertNotNull(this.pseudoConnection);
     this.pseudoConnection.close();
@@ -248,7 +249,7 @@ public class PassthroughServer implements PassthroughDumper {
 
   public void promoteToActive() {
     this.isActive = true;
-    this.serverProcess.shutdown();
+    this.serverProcess.stop();
     // Tell the monitoring producer that we became active.
     this.monitoringProducer.didBecomeActive(this.serverProcess.getServerInfo());
     this.serverProcess.promoteToActive();


### PR DESCRIPTION
-while this change doesn't reflect anything the actual server does, it allows ServiceProviders used in tests an optional hook to close any resources they may require before the passthrough server they were running on is shut down.  In the real server, this isn't done since the server is crash-only, having no clean definition of shutdown.  Since passthrough runs in-process, we use the Closeable as a way to emulate this implicit "clean-up" done by the process termination
-this required creating a distinction between merely "stopping" a server (which happens before shutting it down but also before promoting it to active) and actually "shutting down" a server