### PR TITLE
Pass monitoring data from passive to active

### DIFF
--- a/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughServer.java
+++ b/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughServer.java
@@ -204,6 +204,7 @@ public class PassthroughServer implements PassthroughDumper {
   private void internalStop() {
     this.serverProcess.shutdownServices();
     this.serverProcess.stop();
+    this.monitoringProducer.serverDidStop();
     Assert.assertNotNull(this.pseudoConnection);
     this.pseudoConnection.close();
     this.pseudoConnection = null;
@@ -228,6 +229,11 @@ public class PassthroughServer implements PassthroughDumper {
   }
 
   public void attachDownstreamPassive(PassthroughServer passiveServer) {
+    // Before we attach the downstream to the server process, thus causing the sync, we need to attach the monitoring
+    //  producer, since it needs to know where to forward data to the upstream active.
+    // NOTE:  This will currently call directly since it simplifies the message flow, for now, but this will likely change
+    //  once we have a better sense of how to organize these message channels between the passthrough server processes.
+    passiveServer.monitoringProducer.setUpstreamActive(this.monitoringProducer, passiveServer.serverProcess.getServerInfo());
     this.serverProcess.addDownstreamPassiveServerProcess(passiveServer.serverProcess);
   }
 


### PR DESCRIPTION
NOTE:  This delivers the message to the active service on the passive thread which produced the data.

While this is ideally only temporary until we perform a larger refactoring on the relationships within passthrough, it does have the useful upshot of emulating the way that, on the real server, the active service will see these events coming in on a thread other than the one running the entity invoke calls.