### PR TITLE
Close #70: Add support for ConnectionPropertyNames.CONNECTION_TIMEOUT

### DIFF
--- a/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughConnection.java
+++ b/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughConnection.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Vector;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -73,11 +74,11 @@ public class PassthroughConnection implements Connection {
   private Map<Long, PassthroughWait> waitersToResend;
 
 
-  public PassthroughConnection(String connectionName, String readerThreadName, PassthroughServerProcess serverProcess, List<EntityClientService<?, ?, ? extends EntityMessage, ? extends EntityResponse>> entityClientServices, Runnable onClose, long uniqueConnectionID) {
+  public PassthroughConnection(String connectionName, String readerThreadName, PassthroughServerProcess serverProcess, List<EntityClientService<?, ?, ? extends EntityMessage, ? extends EntityResponse>> entityClientServices, Runnable onClose, long uniqueConnectionID, Properties properties) {
     this.connectionName = connectionName;
     this.uuid = java.util.UUID.randomUUID().toString();
     
-    this.connectionState = new PassthroughConnectionState(serverProcess);
+    this.connectionState = new PassthroughConnectionState(serverProcess, properties);
     this.entityClientServices = entityClientServices;
     this.nextClientEndpointID = 1;
     this.localEndpoints = new HashMap<Long, PassthroughEntityClientEndpoint<?, ?>>();

--- a/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughConnectionService.java
+++ b/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughConnectionService.java
@@ -59,7 +59,7 @@ public class PassthroughConnectionService implements ConnectionService {
       if (null == connectionName) {
         connectionName = "";
       }
-      connection = server.connectNewClient(connectionName);
+      connection = server.connectNewClient(connectionName, properties);
     } else {
       throw new ConnectionException(new UnknownHostException(serverName));
     }

--- a/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughServer.java
+++ b/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughServer.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.ServiceLoader;
 import java.util.Vector;
 import java.util.concurrent.atomic.AtomicLong;
@@ -109,6 +110,10 @@ public class PassthroughServer implements PassthroughDumper {
   }
 
   public synchronized PassthroughConnection connectNewClient(String connectionName) {
+    return connectNewClient(connectionName, new Properties());
+  }
+
+  public synchronized PassthroughConnection connectNewClient(String connectionName, Properties properties) {
     Assert.assertTrue(this.hasStarted);
     final long thisConnectionID = nextConnectionID.incrementAndGet();
     // Note that we need to track the connections for reconnect so pass in this cleanup routine to remove it from our tracking.
@@ -125,7 +130,7 @@ public class PassthroughServer implements PassthroughDumper {
       }
     };
     String readerThreadName = "Client connection " + thisConnectionID;
-    PassthroughConnection connection = new PassthroughConnection(connectionName, readerThreadName, this.serverProcess, this.entityClientServices, onClose, thisConnectionID);
+    PassthroughConnection connection = new PassthroughConnection(connectionName, readerThreadName, this.serverProcess, this.entityClientServices, onClose, thisConnectionID, properties);
     this.serverProcess.connectConnection(connection, thisConnectionID);
     this.savedClientConnections.put(thisConnectionID, connection);
     return connection;
@@ -141,7 +146,7 @@ public class PassthroughServer implements PassthroughDumper {
       }
     };
     String readerThreadName = "Pseudo-connection " + thisConnectionID;
-    return new PassthroughConnection("internal pseudo-connection", readerThreadName, this.serverProcess, this.entityClientServices, onClose, thisConnectionID);
+    return new PassthroughConnection("internal pseudo-connection", readerThreadName, this.serverProcess, this.entityClientServices, onClose, thisConnectionID, new Properties());
   }
 
   public void start(boolean isActive, boolean shouldLoadStorage) {


### PR DESCRIPTION
To overcome being blocked (#70) I implemented support for timeout. I do not know if this is the right thing to do, but it allows invokations to timeout, what we used to have with galvan. In the case of M&M we always use connection timeouts and invokation timeout so in this case, by timeouting, we are able to see the exception reported by junit plus the connection that times out in the tearDown method because the passive failed to become active.