### PR TITLE
Fix terracotta-apis#192 - Add an empty config stream 

### DIFF
--- a/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughPlatformService.java
+++ b/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughPlatformService.java
@@ -1,5 +1,7 @@
 package org.terracotta.passthrough;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import org.terracotta.monitoring.PlatformService;
 
 /**
@@ -17,4 +19,11 @@ public class PassthroughPlatformService implements PlatformService {
     public void dumpPlatformState() {
         passthroughDumper.dump();
     }
+
+    @Override
+    public InputStream getPlatformConfiguration() {
+      return new ByteArrayInputStream(new byte[0]);
+    }
+    
+    
 }

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@ limitations under the License.
     <java.build.version>1.6</java.build.version>
 
     <!-- External dependency versions for the project -->
-    <terracotta-apis.version>1.2.0-pre6</terracotta-apis.version>
+    <terracotta-apis.version>1.2.0-pre8</terracotta-apis.version>
     <galvan.version>1.2.0-pre7</galvan.version>
     <guava.version>18.0</guava.version>
     <junit.version>4.11</junit.version>


### PR DESCRIPTION
so passthrough compiles