### PR TITLE
Update to account for new createNew() exception

### DIFF
--- a/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
+++ b/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughServerProcess.java
@@ -705,6 +705,9 @@ public class PassthroughServerProcess implements MessageHandler, PassthroughDump
     CommonServerEntity<?, ?> newEntity = null;
     try {
       newEntity = createAndStoreEntity(entityClassName, entityName, version, serializedConfiguration, entityTuple, service, registry, consumerID);
+      
+      // Tell the entity to create itself as something new.
+      newEntity.createNew();
     } catch (ConfigurationException e) {
       // Wrap this and re-throw.
       throw new EntityConfigurationException(entityClassName, entityName, e);
@@ -720,9 +723,6 @@ public class PassthroughServerProcess implements MessageHandler, PassthroughDump
       String entityIdentifier = entityIdentifierForService(entityClassName, entityName);
       this.serviceInterface.addNode(PlatformMonitoringConstants.ENTITIES_PATH, entityIdentifier, record);
     }
-    
-    // Tell the entity to create itself as something new.
-    newEntity.createNew();
     
     // If we have a persistence layer, record this.
     EntityData data = new EntityData();

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@ limitations under the License.
     <java.build.version>1.6</java.build.version>
 
     <!-- External dependency versions for the project -->
-    <terracotta-apis.version>1.2.0-pre9</terracotta-apis.version>
+    <terracotta-apis.version>1.2.0-pre12</terracotta-apis.version>
     <galvan.version>1.2.0-pre7</galvan.version>
     <guava.version>18.0</guava.version>
     <junit.version>4.11</junit.version>


### PR DESCRIPTION
-this also re-orders the monitoring events since we recently loosened the expectations that these followed any specific order, relative to entity API calls