### PR TITLE
Fix #96: Set codec early and handle very early message requests

### DIFF
--- a/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughCommunicatorService.java
+++ b/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughCommunicatorService.java
@@ -60,7 +60,7 @@ public class PassthroughCommunicatorService implements ClientCommunicator {
     Future<Void> waiter = connection.createClientResponseFuture();
     
     // We know that the entity better exist, by this point, to use the service.
-    CommonServerEntity<?, ?> entity = this.container.entity;
+    CommonServerEntity<?, ?> entity = this.container.getEntity();
     Assert.assertTrue(null != entity);
     byte[] payload = serialize(this.container.codec, entityMessage);
     PassthroughMessage message = PassthroughMessageCodec.createMessageToClient(clientInstanceID, payload);

--- a/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughMessengerService.java
+++ b/passthrough-server/src/main/java/org/terracotta/passthrough/PassthroughMessengerService.java
@@ -18,20 +18,26 @@
  */
 package org.terracotta.passthrough;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.terracotta.entity.EntityMessage;
 import org.terracotta.entity.IEntityMessenger;
 import org.terracotta.entity.MessageCodec;
 import org.terracotta.entity.MessageCodecException;
 import org.terracotta.passthrough.PassthroughImplementationProvidedServiceProvider.DeferredEntityContainer;
+import org.terracotta.passthrough.PassthroughImplementationProvidedServiceProvider.EntityContainerListener;
 
 
-public class PassthroughMessengerService implements IEntityMessenger {
+public class PassthroughMessengerService implements IEntityMessenger, EntityContainerListener {
   private final PassthroughTimerThread timerThread;
   private final PassthroughServerProcess passthroughServerProcess;
   private final PassthroughConnection pseudoConnection;
   private final DeferredEntityContainer entityContainer;
   private final String entityClassName;
   private final String entityName;
+  // If the entity isn't yet created, we track the invocations in this map.
+  private Map<TokenWrapper, DeferredInvocation> deferredInvocations;
   
   public PassthroughMessengerService(PassthroughTimerThread timerThread, PassthroughServerProcess passthroughServerProcess, PassthroughConnection pseudoConnection, DeferredEntityContainer entityContainer, String entityClassName, String entityName) {
     this.timerThread = timerThread;
@@ -42,6 +48,13 @@ public class PassthroughMessengerService implements IEntityMessenger {
     this.entityContainer = entityContainer;
     this.entityClassName = entityClassName;
     this.entityName = entityName;
+    
+    // Since this service needs access to the entity, potentially before the entity constructor has returned, see if we
+    // need to register for notifications that the entity has been created.
+    if (null == this.entityContainer.getEntity()) {
+      this.deferredInvocations = new HashMap<TokenWrapper, DeferredInvocation>();
+      this.entityContainer.notifyOnEntitySet(this);
+    }
   }
 
   @Override
@@ -67,36 +80,80 @@ public class PassthroughMessengerService implements IEntityMessenger {
   @Override
   public ScheduledToken messageSelfAfterDelay(EntityMessage message, long millisBeforeSend) throws MessageCodecException {
     final PassthroughMessage passthroughMessage = makePassthroughMessage(message);
-    // We need to have the entity at this point.
-    Assert.assertTrue(null != this.entityContainer.entity);
-    long token = this.timerThread.scheduleAfterDelay(new Runnable(){
+    Runnable delayRunnable = new Runnable(){
       @Override
       public void run() {
         // If the entity disappeared, we are implicitly cancelled.
-        if (null != PassthroughMessengerService.this.entityContainer.entity) {
+        if (null != PassthroughMessengerService.this.entityContainer.getEntity()) {
           commonSendMessage(passthroughMessage);
         } else {
           System.err.println("WARNING:  Cancelled SINGLE delayed message to destroyed entity");
         }
-      }}, millisBeforeSend);
-    return new TokenWrapper(token);
+      }};
+    
+    TokenWrapper tokenWrapper = null;
+    // Determine if we can run this, directly, or if we need to defer this until start-up completes.
+    if (null != this.deferredInvocations) {
+      // We are still in start-up so cache this and late-bind the invocation.
+      DeferredInvocation invocation = new DeferredInvocation(delayRunnable, null, millisBeforeSend);
+      tokenWrapper = new TokenWrapper(TokenWrapper.DEFERRED);
+      this.deferredInvocations.put(tokenWrapper, invocation);
+    } else {
+      long token = this.timerThread.scheduleAfterDelay(delayRunnable, millisBeforeSend);
+      tokenWrapper = new TokenWrapper(token);
+    }
+    return tokenWrapper;
   }
 
   @Override
   public ScheduledToken messageSelfPeriodically(EntityMessage message, long millisBetweenSends) throws MessageCodecException {
     final PassthroughMessage passthroughMessage = makePassthroughMessage(message);
-    // We need to have the entity at this point.
-    Assert.assertTrue(null != this.entityContainer.entity);
     SelfCancellingRunnable runnable = new SelfCancellingRunnable(passthroughMessage);
-    long token = this.timerThread.schedulePeriodically(runnable, millisBetweenSends);
-    runnable.setToken(token);
-    return new TokenWrapper(token);
+    
+    TokenWrapper tokenWrapper = null;
+    // Determine if we can run this, directly, or if we need to defer this until start-up completes.
+    if (null != this.deferredInvocations) {
+      // We are still in start-up so cache this and late-bind the invocation.
+      DeferredInvocation invocation = new DeferredInvocation(null, runnable, millisBetweenSends);
+      tokenWrapper = new TokenWrapper(TokenWrapper.DEFERRED);
+      this.deferredInvocations.put(tokenWrapper, invocation);
+    } else {
+      long token = this.timerThread.schedulePeriodically(runnable, millisBetweenSends);
+      runnable.setToken(token);
+      tokenWrapper = new TokenWrapper(token);
+    }
+    return tokenWrapper;
   }
 
   @Override
   public void cancelTimedMessage(ScheduledToken token) {
     // If this is the wrong type, the ClassCastException is a reasonable error since it means we got something invalid.
-    this.timerThread.cancelMessage(((TokenWrapper)token).token);
+    TokenWrapper tokenWrapper = ((TokenWrapper)token);
+    if (null != this.deferredInvocations) {
+      this.deferredInvocations.remove(tokenWrapper);
+    } else {
+      this.timerThread.cancelMessage(tokenWrapper.getToken());
+    }
+  }
+
+  @Override
+  public void entitySetInContainer(DeferredEntityContainer container) {
+    for (Map.Entry<TokenWrapper, DeferredInvocation> entry : this.deferredInvocations.entrySet()) {
+      TokenWrapper wrapper = entry.getKey();
+      DeferredInvocation invocation = entry.getValue();
+      long token = -1;
+      if (null != invocation.delayRunnable) {
+        // Use the delay path.
+        token = this.timerThread.scheduleAfterDelay(invocation.delayRunnable, invocation.delayMillis);
+      } else {
+        Assert.assertTrue(null != invocation.periodicRunnable);
+        // Use the periodic path.
+        token = this.timerThread.schedulePeriodically(invocation.periodicRunnable, invocation.delayMillis);
+        invocation.periodicRunnable.setToken(token);
+      }
+      wrapper.setToken(token);
+    }
+    this.deferredInvocations = null;
   }
 
 
@@ -137,7 +194,7 @@ public class PassthroughMessengerService implements IEntityMessenger {
     public void run() {
       Assert.assertTrue(this.token > 0);
       // If the entity disappeared, we are implicitly cancelled.
-      if (null != PassthroughMessengerService.this.entityContainer.entity) {
+      if (null != PassthroughMessengerService.this.entityContainer.getEntity()) {
         commonSendMessage(this.message);
       } else {
         PassthroughMessengerService.this.timerThread.cancelMessage(this.token);
@@ -148,9 +205,31 @@ public class PassthroughMessengerService implements IEntityMessenger {
 
 
   private static class TokenWrapper implements ScheduledToken {
-    public final long token;
+    public static final long DEFERRED = -1;
+    private long token;
+    
     public TokenWrapper(long token) {
       this.token = token;
+    }
+    public long getToken() {
+      return this.token;
+    }
+    public void setToken(long token) {
+      Assert.assertTrue(DEFERRED == this.token);
+      this.token = token;
+    }
+  }
+
+
+  private static class DeferredInvocation {
+    public final Runnable delayRunnable;
+    public final SelfCancellingRunnable periodicRunnable;
+    public final long delayMillis;
+    
+    public DeferredInvocation(Runnable delayRunnable, SelfCancellingRunnable periodicRunnable, long delayMillis) {
+      this.delayRunnable = delayRunnable;
+      this.periodicRunnable = periodicRunnable;
+      this.delayMillis = delayMillis;
     }
   }
 }


### PR DESCRIPTION
-fixes an NPE when trying to use IEntityMessenger very early in the run
-also fixes an issue where delayed or periodic messages were passed to IEntityMessenger before the entity instance was created and ready to receive the messages