### PR TITLE
Remove POM repositories elements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,12 +40,12 @@ limitations under the License.
 
     <!-- External dependency versions for the project -->
     <guava.version>18.0</guava.version>
-    <terracotta-apis.version>1.8.1</terracotta-apis.version>
-    <galvan.version>1.6.2</galvan.version>
+    <terracotta-apis.version>1.8.2</terracotta-apis.version>
+    <galvan.version>1.6.4</galvan.version>
     <junit.version>4.11</junit.version>
     <mockito.version>1.10.19</mockito.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <tripwire.version>1.0.2</tripwire.version>
+    <tripwire.version>1.0.3</tripwire.version>
   </properties>
 
   <modules>
@@ -117,25 +117,11 @@ limitations under the License.
 
   <repositories>
     <repository>
-      <id>terracotta-snapshots</id>
-      <url>https://www.terracotta.org/download/reflector/snapshots</url>
-    </repository>
-    <repository>
       <id>terracotta-releases</id>
-      <url>https://www.terracotta.org/download/reflector/releases</url>
+      <url>https://repo.terracotta.org/maven2</url>
+      <snapshots><enabled>false</enabled></snapshots>
     </repository>
   </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>terracotta-snapshots</id>
-      <url>https://www.terracotta.org/download/reflector/snapshots</url>
-    </pluginRepository>
-    <pluginRepository>
-      <id>terracotta-releases</id>
-      <url>http://www.terracotta.org/download/reflector/releases</url>
-    </pluginRepository>
-  </pluginRepositories>
 
   <scm>
     <connection>scm:git:https://github.com/Terracotta-OSS/tc-passthrough-testing.git</connection>


### PR DESCRIPTION
This commit reduces the repositories and pluginRepositories elements
to those required to locate the direct dependencies of this project.
More specifically, the SNAPSHOT repositories are removed -- inclusion
of SNAPSHOT repositories interferes with the use of range-based version
specifications.  Should a developer want to include a SNAPSHOT release
in a build, local addition of the SNAPSHOT repositories can be employed.