### PR TITLE
Bump dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,11 +41,11 @@ limitations under the License.
     <!-- External dependency versions for the project -->
     <guava.version>18.0</guava.version>
     <terracotta-apis.version>1.8.2</terracotta-apis.version>
-    <galvan.version>1.6.4</galvan.version>
+    <galvan.version>1.6.5</galvan.version>
     <junit.version>4.11</junit.version>
     <mockito.version>1.10.19</mockito.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <tripwire.version>1.0.3</tripwire.version>
+    <tripwire.version>1.0.4</tripwire.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
This commit bumps the versions of galvan to 1.6.5 and
tc-tripwire to 1.0.4.

This sets in place versions of galvan and tc-tripwire that use range versions for logging components and terracotta-utilities.